### PR TITLE
Clean up Arithmetic.Fin

### DIFF
--- a/natural-arithmetic.cabal
+++ b/natural-arithmetic.cabal
@@ -42,6 +42,16 @@ description:
   Consequently, we only provide a single `plus` function, and users
   must use `Arithmetic.Plus.commutative` to further manipulate the
   inequality.
+  .
+  Here are the proof-manipulation vocabulary used by this library.
+  Many of these terms are not standard, but we try to be consistent
+  in this library:
+  .
+  * Weaken: Increase an upper bound without changing the bounded value
+  .
+  * Increment: Increase an upper bound along with the bounded value
+  .
+  * Substitute: Replace a number with an equal number
 bug-reports: https://github.com/andrewthad/natural-arithmetic
 license: BSD-3-Clause
 license-file: LICENSE

--- a/natural-arithmetic.cabal
+++ b/natural-arithmetic.cabal
@@ -29,6 +29,19 @@ description:
   of making it easy for user to assemble proofs. Recall that proof
   assembly is done by hand rather than by an SMT solver, so removing
   some tediousness from this is helpful to users. 
+  .
+  This library provides left and variants variants of several functions.
+  For example, `Arithmetic.Lte` provides both `substituteL` and
+  `substituteR`. This is only done when there are two variants of
+  a function. For substitution, this is the case because we have
+  `b = c, a ≤ b ==> a ≤ c` and `a = c, a ≤ b ==> c ≤ b`. So, we
+  provide both `substituteL` and `substituteR`. However,
+  for addition of inequalities, we have four possible variants:
+  `a ≤ b, c ≤ d ==> a + c ≤ b + d`, `a ≤ b, c ≤ d ==> c + a ≤ b + d`,
+  `a ≤ b, c ≤ d ==> a + c ≤ d + b`, `a ≤ b, c ≤ d ==> c + a ≤ d + b`.
+  Consequently, we only provide a single `plus` function, and users
+  must use `Arithmetic.Plus.commutative` to further manipulate the
+  inequality.
 bug-reports: https://github.com/andrewthad/natural-arithmetic
 license: BSD-3-Clause
 license-file: LICENSE

--- a/src/Arithmetic/Equal.hs
+++ b/src/Arithmetic/Equal.hs
@@ -1,7 +1,7 @@
 {-# language DataKinds #-}
-{-# language TypeOperators #-}
-{-# language KindSignatures #-}
 {-# language ExplicitForAll #-}
+{-# language KindSignatures #-}
+{-# language TypeOperators #-}
 
 module Arithmetic.Equal
   ( symmetric

--- a/src/Arithmetic/Equal.hs
+++ b/src/Arithmetic/Equal.hs
@@ -9,14 +9,14 @@ module Arithmetic.Equal
   , plusL
   ) where
 
-import Arithmetic.Unsafe (type (:=:)(Equal))
+import Arithmetic.Unsafe (type (:=:)(Eq))
 import GHC.TypeNats (type (+))
 
 symmetric :: (m :=: n) -> (n :=: m)
-symmetric Equal = Equal
+symmetric Eq = Eq
 
 plusL :: forall c m n. (m :=: n) -> (c + m :=: c + n)
-plusL Equal = Equal
+plusL Eq = Eq
 
 plusR :: forall c m n. (m :=: n) -> (m + c :=: n + c)
-plusR Equal = Equal
+plusR Eq = Eq

--- a/src/Arithmetic/Fin.hs
+++ b/src/Arithmetic/Fin.hs
@@ -1,11 +1,11 @@
 {-# language BangPatterns #-}
 {-# language DataKinds #-}
-{-# language GADTs #-}
-{-# language ScopedTypeVariables #-}
-{-# language KindSignatures #-}
-{-# language TypeOperators #-}
-{-# language TypeApplications #-}
 {-# language ExplicitNamespaces #-}
+{-# language GADTs #-}
+{-# language KindSignatures #-}
+{-# language ScopedTypeVariables #-}
+{-# language TypeApplications #-}
+{-# language TypeOperators #-}
 module Arithmetic.Fin
   ( -- * Modification
     incrementL
@@ -26,12 +26,14 @@ module Arithmetic.Fin
   ) where
 
 import Prelude hiding (last)
-import GHC.TypeNats (type (+))
+
 import Arithmetic.Nat ((<?))
 import Arithmetic.Types (Fin(..),Difference(..),Nat,type (<), type (<=), type (:=:))
-import qualified Arithmetic.Nat as Nat
+import GHC.TypeNats (type (+))
+
 import qualified Arithmetic.Lt as Lt
 import qualified Arithmetic.Lte as Lte
+import qualified Arithmetic.Nat as Nat
 import qualified Arithmetic.Plus as Plus
 
 -- | Raise the index by @m@ and weaken the bound by @m@, adding

--- a/src/Arithmetic/Fin.hs
+++ b/src/Arithmetic/Fin.hs
@@ -19,7 +19,7 @@ module Arithmetic.Fin
   , weakenL
   , weakenR
     -- * Absurdities
-  , finZeroAbsurd
+  , absurd
     -- * Demote
   , demote
   ) where
@@ -63,9 +63,9 @@ weakenL (Fin i pf) = Fin i
 weakenR :: forall n m. Fin n -> Fin (n + m)
 weakenR (Fin i pf) = Fin i (Lt.plus pf Lte.zero)
 
--- | A finite set of no values is impossible
-finZeroAbsurd :: Fin 0 -> void
-finZeroAbsurd (Fin _ pf) = Lt.lessThanZeroAbsurd pf
+-- | A finite set of no values is impossible.
+absurd :: Fin 0 -> void
+absurd (Fin _ pf) = Lt.absurd pf
 
 -- | Generate all values of a finite set in ascending order
 -- >>> ascending (Nat.constant @3) (Lt.constant @3)

--- a/src/Arithmetic/Fin.hs
+++ b/src/Arithmetic/Fin.hs
@@ -14,8 +14,8 @@ module Arithmetic.Fin
   , descending
   , slice
     -- * Modification
-  , shiftL
-  , shiftR
+  , incrementL
+  , incrementR
   , weakenL
   , weakenR
     -- * Absurdities
@@ -43,13 +43,13 @@ last n !pf = Fin (Nat (getNat n - 1)) pf
 
 -- | Raise the index by @m@ and weaken the bound by @m@, adding
 -- @m@ to the right-hand side of @n@.
-shiftR :: forall n m. Nat m -> Fin n -> Fin (n + m)
-shiftR m (Fin i pf) = Fin (Nat.plus i m) (Lt.incrementR @m pf)
+incrementR :: forall n m. Nat m -> Fin n -> Fin (n + m)
+incrementR m (Fin i pf) = Fin (Nat.plus i m) (Lt.incrementR @m pf)
 
 -- | Raise the index by @m@ and weaken the bound by @m@, adding
 -- @m@ to the left-hand side of @n@.
-shiftL :: forall n m. Nat m -> Fin n -> Fin (m + n)
-shiftL m (Fin i pf) = Fin (Nat.plus m i) (Lt.incrementL @m pf)
+incrementL :: forall n m. Nat m -> Fin n -> Fin (m + n)
+incrementL m (Fin i pf) = Fin (Nat.plus m i) (Lt.incrementL @m pf)
 
 -- | Weaken the bound by one. This does not change the index.
 weakenL :: forall n m. Fin n -> Fin (m + n)

--- a/src/Arithmetic/Fin.hs
+++ b/src/Arithmetic/Fin.hs
@@ -18,7 +18,7 @@ module Arithmetic.Fin
   , ascendM_
   , ascending
   , descending
-  , slice
+  , ascendingSlice
     -- * Absurdities
   , absurd
     -- * Demote
@@ -152,12 +152,12 @@ descending n = go n Lte.reflexive
 --
 -- >>> slice (Nat.constant @2) (Nat.constant @3) (Lt.constant @6)
 -- [2, 3, 4]
-slice :: forall n off len.
+ascendingSlice :: forall n off len.
      Nat off
   -> Nat len
   -> (off + len < n)
   -> [Fin n]
-slice off len !offPlusLenLtEn = go Nat.zero
+ascendingSlice off len !offPlusLenLtEn = go Nat.zero
   where
     go :: Nat m -> [Fin n]
     go !m = case m <? len of

--- a/src/Arithmetic/Lt.hs
+++ b/src/Arithmetic/Lt.hs
@@ -19,6 +19,8 @@ module Arithmetic.Lt
     -- * Composition
   , plus
   , transitive
+  , transitiveNonstrictL
+  , transitiveNonstrictR
     -- * Absurdities
   , absurd
     -- * Integration with GHC solver
@@ -71,6 +73,14 @@ weakenR Lt = Lt
 -- | Compose two strict inequalities using transitivity.
 transitive :: (a < b) -> (b < c) -> (a < c)
 transitive Lt Lt = Lt
+
+-- | Compose a strict inequality (the first argument) with a nonstrict
+-- inequality (the second argument).
+transitiveNonstrictR :: (a < b) -> (b <= c) -> (a < c)
+transitiveNonstrictR Lt Lte = Lt
+
+transitiveNonstrictL :: (a <= b) -> (b < c) -> (a < c)
+transitiveNonstrictL Lte Lt = Lt
 
 -- | Zero is less than one.
 zero :: 0 < 1

--- a/src/Arithmetic/Lt.hs
+++ b/src/Arithmetic/Lt.hs
@@ -1,8 +1,8 @@
 {-# language DataKinds #-}
-{-# language TypeOperators #-}
-{-# language KindSignatures #-}
 {-# language ExplicitForAll #-}
+{-# language KindSignatures #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 
 module Arithmetic.Lt
   ( -- * Special Inequalities
@@ -30,6 +30,7 @@ module Arithmetic.Lt
 import Arithmetic.Unsafe (type (<)(Lt),type (:=:)(Eq))
 import Arithmetic.Unsafe (type (<=)(Lte))
 import GHC.TypeNats (CmpNat,type (+))
+
 import qualified GHC.TypeNats as GHC
 
 -- | Replace the right-hand side of a strict inequality

--- a/src/Arithmetic/Lt.hs
+++ b/src/Arithmetic/Lt.hs
@@ -22,7 +22,7 @@ module Arithmetic.Lt
   , constant
   ) where
 
-import Arithmetic.Unsafe (type (<)(Lt),type (:=:)(Equal))
+import Arithmetic.Unsafe (type (<)(Lt),type (:=:)(Eq))
 import Arithmetic.Unsafe (type (<=)(Lte))
 import GHC.TypeNats (CmpNat,type (+))
 import qualified GHC.TypeNats as GHC
@@ -30,12 +30,12 @@ import qualified GHC.TypeNats as GHC
 -- | Replace the right-hand side of a strict inequality
 -- with an equal number.
 substituteL :: (b :=: c) -> (a < b) -> (a < c)
-substituteL Equal Lt = Lt
+substituteL Eq Lt = Lt
 
 -- | Replace the right-hand side of a strict inequality
 -- with an equal number.
 substituteR :: (b :=: c) -> (a < b) -> (a < c)
-substituteR Equal Lt = Lt
+substituteR Eq Lt = Lt
 
 -- | Add a strict inequality to a nonstrict inequality.
 plus :: (a < b) -> (c <= d) -> (a + c < b + d)

--- a/src/Arithmetic/Lt.hs
+++ b/src/Arithmetic/Lt.hs
@@ -5,15 +5,18 @@
 {-# language TypeFamilies #-}
 
 module Arithmetic.Lt
-  ( -- * Identity
+  ( -- * Special Inequalities
     zero
     -- * Substitution
   , substituteL
   , substituteR
-    -- * Congruence
+    -- * Increment
   , incrementL
   , incrementR
-    -- * Composition of Inequalities
+    -- * Weaken
+  , weakenL
+  , weakenR
+    -- * Composition
   , plus
   , transitive
     -- * Absurdities
@@ -52,6 +55,18 @@ incrementL Lt = Lt
 incrementR :: forall (c :: GHC.Nat) (a :: GHC.Nat) (b :: GHC.Nat).
   (a < b) -> (a + c < b + c)
 incrementR Lt = Lt
+
+-- | Add a constant to the left-hand side of the right-hand side of
+-- the strict inequality.
+weakenL :: forall (c :: GHC.Nat) (a :: GHC.Nat) (b :: GHC.Nat).
+  (a < b) -> (a < c + b)
+weakenL Lt = Lt
+
+-- | Add a constant to the right-hand side of the right-hand side of
+-- the strict inequality.
+weakenR :: forall (c :: GHC.Nat) (a :: GHC.Nat) (b :: GHC.Nat).
+  (a < b) -> (a < b + c)
+weakenR Lt = Lt
 
 -- | Compose two strict inequalities using transitivity.
 transitive :: (a < b) -> (b < c) -> (a < c)

--- a/src/Arithmetic/Lt.hs
+++ b/src/Arithmetic/Lt.hs
@@ -17,7 +17,7 @@ module Arithmetic.Lt
   , plus
   , transitive
     -- * Absurdities
-  , lessThanZeroAbsurd
+  , absurd
     -- * Integration with GHC solver
   , constant
   ) where
@@ -62,8 +62,8 @@ zero :: 0 < 1
 zero = Lt
 
 -- | Nothing is less than zero.
-lessThanZeroAbsurd :: n < 0 -> void
-lessThanZeroAbsurd Lt = error "Arithmetic.Nat.lessThanZeroAbsurd: n < 0"
+absurd :: n < 0 -> void
+absurd Lt = error "Arithmetic.Nat.absurd: n < 0"
 
 -- | Use GHC's built-in type-level arithmetic to prove
 -- that one number is less than another. The type-checker

--- a/src/Arithmetic/Lte.hs
+++ b/src/Arithmetic/Lte.hs
@@ -5,14 +5,22 @@
 {-# language TypeOperators #-}
 
 module Arithmetic.Lte
-  ( transitive
-  , plus
-  , zero
+  ( -- * Special Inequalities
+    zero
+  , reflexive
+    -- * Substitution
   , substituteL
   , substituteR
+    -- * Increment
   , incrementL
   , incrementR
-  , reflexive
+    -- * Weaken
+  , weakenL
+  , weakenR
+    -- * Composition
+  , transitive
+  , plus
+    -- * Convert Strict Inequality
   , fromStrict
     -- * Integration with GHC solver
   , constant
@@ -57,13 +65,29 @@ incrementR :: forall (c :: GHC.Nat) (a :: GHC.Nat) (b :: GHC.Nat).
   (a <= b) -> (a + c <= b + c)
 incrementR Lte = Lte
 
--- | Weaken a strict inequality.
+-- | Add a constant to the left-hand side of the right-hand side of
+-- the inequality.
+weakenL :: forall (c :: GHC.Nat) (a :: GHC.Nat) (b :: GHC.Nat).
+  (a <= b) -> (a <= c + b)
+weakenL Lte = Lte
+
+-- | Add a constant to the right-hand side of the right-hand side of
+-- the inequality.
+weakenR :: forall (c :: GHC.Nat) (a :: GHC.Nat) (b :: GHC.Nat).
+  (a <= b) -> (a <= b + c)
+weakenR Lte = Lte
+
+-- | Weaken a strict inequality to a non-strict inequality.
 fromStrict :: (a < b) -> (a <= b)
 fromStrict Lt = Lte
 
+-- | Zero is less-than-or-equal-to any number.
 zero :: 0 <= a
 zero = Lte
 
+-- | Use GHC's built-in type-level arithmetic to prove
+-- that one number is less-than-or-equal-to another. The type-checker
+-- only reduces 'CmpNat' if both arguments are constants.
 constant :: forall a b. (IsLte (CmpNat a b) ~ 'True) => (a <= b)
 constant = Lte
 

--- a/src/Arithmetic/Lte.hs
+++ b/src/Arithmetic/Lte.hs
@@ -18,7 +18,7 @@ module Arithmetic.Lte
   , constant
   ) where
 
-import Arithmetic.Unsafe (type (<)(Lt),type (:=:)(Equal))
+import Arithmetic.Unsafe (type (<)(Lt),type (:=:)(Eq))
 import Arithmetic.Unsafe (type (<=)(Lte))
 import GHC.TypeNats (CmpNat,type (+))
 import qualified GHC.TypeNats as GHC
@@ -26,12 +26,12 @@ import qualified GHC.TypeNats as GHC
 -- | Replace the right-hand side of a strict inequality
 -- with an equal number.
 substituteL :: (b :=: c) -> (a < b) -> (a < c)
-substituteL Equal Lt = Lt
+substituteL Eq Lt = Lt
 
 -- | Replace the right-hand side of a strict inequality
 -- with an equal number.
 substituteR :: (b :=: c) -> (a < b) -> (a < c)
-substituteR Equal Lt = Lt
+substituteR Eq Lt = Lt
 
 -- | Add two inequalities.
 plus :: (a <= b) -> (c <= d) -> (a + c <= b + d)

--- a/src/Arithmetic/Lte.hs
+++ b/src/Arithmetic/Lte.hs
@@ -32,6 +32,7 @@ module Arithmetic.Lte
 import Arithmetic.Unsafe (type (<)(Lt),type (:=:)(Eq))
 import Arithmetic.Unsafe (type (<=)(Lte))
 import GHC.TypeNats (CmpNat,type (+))
+
 import qualified GHC.TypeNats as GHC
 
 -- | Replace the right-hand side of a strict inequality

--- a/src/Arithmetic/Lte.hs
+++ b/src/Arithmetic/Lte.hs
@@ -14,6 +14,9 @@ module Arithmetic.Lte
     -- * Increment
   , incrementL
   , incrementR
+    -- * Decrement
+  , decrementL
+  , decrementR
     -- * Weaken
   , weakenL
   , weakenR
@@ -33,13 +36,13 @@ import qualified GHC.TypeNats as GHC
 
 -- | Replace the right-hand side of a strict inequality
 -- with an equal number.
-substituteL :: (b :=: c) -> (a < b) -> (a < c)
-substituteL Eq Lt = Lt
+substituteL :: (b :=: c) -> (a <= b) -> (a <= c)
+substituteL Eq Lte = Lte
 
 -- | Replace the right-hand side of a strict inequality
 -- with an equal number.
-substituteR :: (b :=: c) -> (a < b) -> (a < c)
-substituteR Eq Lt = Lt
+substituteR :: (b :=: c) -> (a <= b) -> (a <= c)
+substituteR Eq Lte = Lte
 
 -- | Add two inequalities.
 plus :: (a <= b) -> (c <= d) -> (a + c <= b + d)
@@ -76,6 +79,18 @@ weakenL Lte = Lte
 weakenR :: forall (c :: GHC.Nat) (a :: GHC.Nat) (b :: GHC.Nat).
   (a <= b) -> (a <= b + c)
 weakenR Lte = Lte
+
+-- | Subtract a constant from the left-hand side of both sides of
+-- the inequality. This is the opposite of 'incrementL'.
+decrementL :: forall (c :: GHC.Nat) (a :: GHC.Nat) (b :: GHC.Nat).
+  (c + a <= c + b) -> (a <= b)
+decrementL Lte = Lte
+
+-- | Subtract a constant from the right-hand side of both sides of
+-- the inequality. This is the opposite of 'incrementR'.
+decrementR :: forall (c :: GHC.Nat) (a :: GHC.Nat) (b :: GHC.Nat).
+  (a + c <= b + c) -> (a <= b)
+decrementR Lte = Lte
 
 -- | Weaken a strict inequality to a non-strict inequality.
 fromStrict :: (a < b) -> (a <= b)

--- a/src/Arithmetic/Nat.hs
+++ b/src/Arithmetic/Nat.hs
@@ -28,7 +28,7 @@ module Arithmetic.Nat
 import Prelude hiding (succ)
 
 import Arithmetic.Unsafe (Nat(Nat),type (<)(Lt))
-import Arithmetic.Unsafe ((:=:)(Equal), type (<=)(Lte))
+import Arithmetic.Unsafe ((:=:)(Eq), type (<=)(Lte))
 import GHC.Exts (Proxy#,proxy#)
 import GHC.TypeNats (type (+),KnownNat,natVal')
 
@@ -61,7 +61,7 @@ testLessThanEqual (Nat x) (Nat y) = if x <= y
 -- | Are the two arguments equal to one another?
 testEqual :: Nat a -> Nat b -> Maybe (a :=: b)
 testEqual (Nat x) (Nat y) = if x == y
-  then Just Equal
+  then Just Eq
   else Nothing
 
 -- | Add two numbers.

--- a/src/Arithmetic/Nat.hs
+++ b/src/Arithmetic/Nat.hs
@@ -8,6 +8,8 @@
 module Arithmetic.Nat
   ( -- * Addition
     plus
+    -- * Subtraction
+  , monus
     -- * Successor
   , succ
     -- * Compare
@@ -29,6 +31,7 @@ import Prelude hiding (succ)
 
 import Arithmetic.Unsafe (Nat(Nat),type (<)(Lt))
 import Arithmetic.Unsafe ((:=:)(Eq), type (<=)(Lte))
+import Arithmetic.Types
 import GHC.Exts (Proxy#,proxy#)
 import GHC.TypeNats (type (+),KnownNat,natVal')
 
@@ -71,6 +74,13 @@ plus (Nat x) (Nat y) = Nat (x + y)
 -- | The successor of a number.
 succ :: Nat a -> Nat (a + 1)
 succ n = plus n one
+
+-- | Subtract the second argument from the first argument.
+monus :: Nat a -> Nat b -> Maybe (Difference a b)
+{-# inline monus #-}
+monus (Nat a) (Nat b) = let c = a - b in if c >= 0
+  then Just (Difference (Nat c) Eq)
+  else Nothing
 
 -- | The number zero.
 zero :: Nat 0

--- a/src/Arithmetic/Nat.hs
+++ b/src/Arithmetic/Nat.hs
@@ -1,9 +1,9 @@
 {-# language DataKinds #-}
-{-# language TypeOperators #-}
-{-# language KindSignatures #-}
 {-# language ExplicitForAll #-}
+{-# language KindSignatures #-}
 {-# language MagicHash #-}
 {-# language ScopedTypeVariables #-}
+{-# language TypeOperators #-}
 
 module Arithmetic.Nat
   ( -- * Addition
@@ -29,9 +29,9 @@ module Arithmetic.Nat
 
 import Prelude hiding (succ)
 
-import Arithmetic.Unsafe (Nat(Nat),type (<)(Lt))
-import Arithmetic.Unsafe ((:=:)(Eq), type (<=)(Lte))
 import Arithmetic.Types
+import Arithmetic.Unsafe ((:=:)(Eq), type (<=)(Lte))
+import Arithmetic.Unsafe (Nat(Nat),type (<)(Lt))
 import GHC.Exts (Proxy#,proxy#)
 import GHC.TypeNats (type (+),KnownNat,natVal')
 

--- a/src/Arithmetic/Plus.hs
+++ b/src/Arithmetic/Plus.hs
@@ -19,7 +19,7 @@ zeroR :: m :=: (m + 0)
 zeroR = Eq
 
 -- | Zero plus any number is equal to the original number.
-zeroL :: m :=: (m + 0)
+zeroL :: m :=: (0 + m)
 zeroL = Eq
 
 -- | Addition is commutative.

--- a/src/Arithmetic/Plus.hs
+++ b/src/Arithmetic/Plus.hs
@@ -11,21 +11,21 @@ module Arithmetic.Plus
   , associative
   ) where
 
-import Arithmetic.Unsafe (type (:=:)(Equal))
+import Arithmetic.Unsafe (type (:=:)(Eq))
 import GHC.TypeNats (type (+))
 
 -- | Any number plus zero is equal to the original number.
 zeroR :: m :=: (m + 0)
-zeroR = Equal
+zeroR = Eq
 
 -- | Zero plus any number is equal to the original number.
 zeroL :: m :=: (m + 0)
-zeroL = Equal
+zeroL = Eq
 
 -- | Addition is commutative.
 commutative :: forall a b. a + b :=: b + a
-commutative = Equal
+commutative = Eq
 
 -- | Addition is associative.
 associative :: forall a b c. (a + b) + c :=: a + (b + c)
-associative = Equal
+associative = Eq

--- a/src/Arithmetic/Types.hs
+++ b/src/Arithmetic/Types.hs
@@ -1,9 +1,9 @@
+{-# language DataKinds #-}
 {-# language ExplicitNamespaces #-}
 {-# language GADTs #-}
+{-# language KindSignatures #-}
 {-# language RankNTypes #-}
 {-# language TypeOperators #-}
-{-# language DataKinds #-}
-{-# language KindSignatures #-}
 
 module Arithmetic.Types
   ( Nat
@@ -14,10 +14,11 @@ module Arithmetic.Types
   , type (:=:)
   ) where
 
-import Data.Kind (type Type)
 import Arithmetic.Unsafe (Nat(getNat), type (<=))
 import Arithmetic.Unsafe (type (<), type (:=:))
+import Data.Kind (type Type)
 import GHC.TypeNats (type (+))
+
 import qualified GHC.TypeNats as GHC
 
 -- | A finite set of 'n' elements. 'Fin n = { 0 .. n - 1 }'

--- a/src/Arithmetic/Types.hs
+++ b/src/Arithmetic/Types.hs
@@ -7,6 +7,7 @@
 
 module Arithmetic.Types
   ( Nat
+  , Difference(..)
   , Fin(..)
   , type (<)
   , type (<=)
@@ -16,14 +17,23 @@ module Arithmetic.Types
 import Data.Kind (type Type)
 import Arithmetic.Unsafe (Nat(getNat), type (<=))
 import Arithmetic.Unsafe (type (<), type (:=:))
+import GHC.TypeNats (type (+))
 import qualified GHC.TypeNats as GHC
 
 -- | A finite set of 'n' elements. 'Fin n = { 0 .. n - 1 }'
 data Fin :: GHC.Nat -> Type where
-  Fin :: forall n m.
+  Fin :: forall m n.
     { index :: !(Nat m)
     , proof :: !(m < n)
     } -> Fin n
+
+-- | Proof that the first argument can be expressed as the
+-- sum of the second argument and some other natural number.
+data Difference :: GHC.Nat -> GHC.Nat -> Type where
+  -- It is safe for users of this library to use this data constructor
+  -- freely. However, note that the interesting Difference values come
+  -- from Arithmetic.Nat.monus, which is a primitive.
+  Difference :: forall a b c. Nat c -> (c + b :=: a) -> Difference a b
 
 instance Show (Fin n) where
   showsPrec p (Fin i _) = showString "Fin " . showsPrec p (getNat i)

--- a/src/Arithmetic/Unsafe.hs
+++ b/src/Arithmetic/Unsafe.hs
@@ -1,9 +1,9 @@
-{-# language RoleAnnotations #-}
 {-# language DataKinds #-}
+{-# language ExplicitNamespaces #-}
 {-# language GADTSyntax #-}
 {-# language KindSignatures #-}
+{-# language RoleAnnotations #-}
 {-# language TypeOperators #-}
-{-# language ExplicitNamespaces #-}
 
 module Arithmetic.Unsafe
   ( Nat(..)
@@ -13,8 +13,10 @@ module Arithmetic.Unsafe
   ) where
 
 import Prelude hiding ((>=),(<=))
-import Data.Kind (Type)
+
 import Control.Category (Category)
+import Data.Kind (Type)
+
 import qualified Control.Category
 import qualified GHC.TypeNats as GHC
 
@@ -22,7 +24,7 @@ import qualified GHC.TypeNats as GHC
 -- Using this library to implement length-indexed arrays
 -- or sized builders does not require importing this
 -- module to get the value out of the Nat data constructor.
--- Use Arithmetic.Nat.
+-- Use Arithmetic.Nat.demote for this purpose.
 
 infix 4 <
 infix 4 <=
@@ -32,12 +34,17 @@ infix 4 :=:
 newtype Nat (n :: GHC.Nat) = Nat { getNat :: Int }
 type role Nat nominal
 
+-- | Proof that the first argument is strictly less than the
+-- second argument.
 data (<) :: GHC.Nat -> GHC.Nat -> Type where
   Lt :: a < b
 
+-- | Proof that the first argument is less than or equal to the
+-- second argument.
 data (<=) :: GHC.Nat -> GHC.Nat -> Type where
   Lte :: a <= b
 
+-- | Proof that the first argument is equal to the second argument.
 data (:=:) :: GHC.Nat -> GHC.Nat -> Type where
   Eq :: a :=: b
 

--- a/src/Arithmetic/Unsafe.hs
+++ b/src/Arithmetic/Unsafe.hs
@@ -9,7 +9,7 @@ module Arithmetic.Unsafe
   ( Nat(..)
   , type (<)(Lt)
   , type (<=)(Lte)
-  , type (:=:)(Equal)
+  , type (:=:)(Eq)
   ) where
 
 import Prelude hiding ((>=),(<=))
@@ -39,12 +39,12 @@ data (<=) :: GHC.Nat -> GHC.Nat -> Type where
   Lte :: a <= b
 
 data (:=:) :: GHC.Nat -> GHC.Nat -> Type where
-  Equal :: a :=: b
+  Eq :: a :=: b
 
 instance Category (<=) where
   id = Lte
   Lte . Lte = Lte
 
 instance Category (:=:) where
-  id = Equal
-  Equal . Equal = Equal
+  id = Eq
+  Eq . Eq = Eq


### PR DESCRIPTION
Commit message: Add left-plus and right-plus variants of bound-manipulation functions in Arithmetic.Fin. Document this convention. Rename raise to shift.

Agda uses the name `raise`. Idris uses `shift`. I think that `shift` is more appropriate of Haskell, since `raise` implies throwing an exception. I've removed the specializations of `shift` and `weaken` that increment by one since it is trivial for users to write `weakenL Nat.one fin`. In the cabal file, I've attempted to explain the convention of having left and right variants of functions. In practice, I've found that this makes this library considerably easier to use. Having to write `Plus.commutative` (often lifting it over another proof) makes for a miserable user experience and makes the resulting proofs unreadable.

@mckeankylej Wanted to get any of your thoughts.